### PR TITLE
Use return code '2' for critical errors

### DIFF
--- a/reduce_src/FlipMemo.cpp
+++ b/reduce_src/FlipMemo.cpp
@@ -994,7 +994,7 @@ int FlipMemo::findAtom( PDBrec * atom ) const
 	{
 		std::cerr << " &_wrkAtom[ ii ] " << &_wrkAtom[ ii ]  << std::endl;
 	}
-	exit(1);
+	exit(2);
         return 0; // to avoid warnings
 }
 

--- a/reduce_src/GraphToHoldScores.cpp
+++ b/reduce_src/GraphToHoldScores.cpp
@@ -1152,7 +1152,7 @@ DegreeTwoEdge_ths::whichVertex( int vertex_index ) const
 	std::cerr << "CRITICAL ERROR IN whichVertex(" << vertex_index << ") called on edge ["
 		  << vertex_indices_[ 0 ] << ", " << vertex_indices_[ 1 ] << "]" << std::endl;
 	assert(false);
-	exit(1);
+	exit(2);
         return 0; // to avoid warnings
 }
 
@@ -1539,7 +1539,7 @@ DegreeThreeEdge_ths::whichVertex( int vertex ) const
 	std::cerr << vertex_indices_[ 0 ] << ", " << vertex_indices_[ 1 ] << ", " << vertex_indices_[ 2 ];
 	std::cerr << "]" << std::endl;
 	assert( false );
-	exit(1);
+	exit(2);
         return 0; // to avoid warnings
 }
 
@@ -1984,7 +1984,7 @@ DegreeFourEdge_ths::whichVertex( int vertex ) const
 	std::cerr << vertex_indices_[ 2 ] << ", " << vertex_indices_[ 3 ];
 	std::cerr << "]" << std::endl;
 	assert( false );
-	exit(1);
+	exit(2);
         return 0; // to avoid warnings
 }
 

--- a/reduce_src/MoveableNode.cpp
+++ b/reduce_src/MoveableNode.cpp
@@ -1239,7 +1239,7 @@ void 				MoveableNode::beNotifiedDependencyEliminated(int i)
 	{
 		std::cerr << "Edge between this node and the other node (" << _index << " and " << i << " ) not found\n.";
 		std::cerr << "Critical Error: Graph incorrectly initialized!" << std::endl;
-		exit(1);
+		exit(2);
 	}
 
 	if (_edgeList.size() == 1)

--- a/reduce_src/RotAromMethyl.cpp
+++ b/reduce_src/RotAromMethyl.cpp
@@ -351,6 +351,6 @@ int RotAromMethyl::findAtom( PDBrec* atom ) const
 		std::cerr << "_rot: " << *iter << std::endl;
 	}
 
-	exit(1);
+	exit(2);
         return 0; // to avoid warnings
 }

--- a/reduce_src/RotDonor.cpp
+++ b/reduce_src/RotDonor.cpp
@@ -431,7 +431,7 @@ int RotDonor::findAtom( PDBrec* atom ) const
 		std::cerr << "_rot: " << *iter << std::endl;
 	}
 
-	exit(1);
+	exit(2);
         return 0; // to avoid warnings
 }
 

--- a/reduce_src/RotMethyl.cpp
+++ b/reduce_src/RotMethyl.cpp
@@ -341,6 +341,6 @@ int RotMethyl::findAtom( PDBrec* atom ) const
 		std::cerr << "_rot: " << *iter << std::endl;
 	}
 
-	exit(1);
+	exit(2);
         return 0; // to avoid warnings
 }

--- a/reduce_src/reduce.cpp
+++ b/reduce_src/reduce.cpp
@@ -593,7 +593,7 @@ char* parseCommandLine(int argc, char **argv) {
       }
       else if((n = compArgStr(p+1, "Version", 1))){
         cerr << shortVersion << endl;
-        exit(1);
+        exit(2);
       }
       else if((n = compArgStr(p+1, "Changes", 1))) {
         reduceChanges(TRUE);
@@ -633,7 +633,7 @@ char* parseCommandLine(int argc, char **argv) {
       }
       else if((n = compArgStr(p+1, "Xplor", 1)) && UseOldNames){
         cerr << "Cannot use both -Xplor and -OLDpdb flags" << endl;
-        exit(1);
+        exit(2);
       }
       else if((n = compArgStr(p+1, "OLDpdb", 3)) && ! UseXplorNames){
         UseOldNames = TRUE;
@@ -641,7 +641,7 @@ char* parseCommandLine(int argc, char **argv) {
       }
       else if((n = compArgStr(p+1, "OLDpdb", 3)) && UseXplorNames){
         cerr << "Cannot use both -Xplor and -OLDpdb flags" << endl;
-        exit(1);
+        exit(2);
       }
       else if((n = compArgStr(p+1, "BBmodel", 2))){
         BackBoneModel = TRUE;
@@ -743,13 +743,13 @@ char* parseCommandLine(int argc, char **argv) {
         GapWidth = parseReal(p, n+1, 10, GapWidth);
         if (GapWidth > 1.4) {
           cerr << "Max allowed HalfGapWidth is 1.4" << endl;
-          exit(1);
+          exit(2);
         }
       }
       else if((n = compArgStr(p+1, "REFerence", 3))){
         cerr << "Please cite: " << referenceString << endl;
         cerr << "For more information see " << electronicReference << endl;
-        exit(1);
+        exit(2);
       }
       else if((n = compArgStr(p+1, "FIX", 3))){
         if (++i < argc) {
@@ -882,7 +882,7 @@ void reduceHelp(bool showAll) { /*help*/
    cerr << "-Version          display the version of reduce" <<endl;
    cerr << "-Changes          display the change log" <<endl;
    cerr << "-Help             the more extensive description of command line arguments" << endl;
-   exit(1);
+   exit(2);
 }
 
 void reduceChanges(bool showAll) { /*changes*/
@@ -1071,7 +1071,7 @@ void reduceChanges(bool showAll) { /*changes*/
    cerr  << "2015/??    - bjh       test system" << endl;
    cerr  << "2016/06/02 - cjw       set default behavior *not* to rotate methionine methyls, added -DOROTMET flag" << endl;
    cerr  << endl;
-   exit(1);
+   exit(2);
 }
 
 // SJ 08/03/2015 for printing all records together


### PR DESCRIPTION
This allows external scripts to distinguish aborted runs with incomplete
results due to critical errors from completed runs with abandoned clique searches.

The return code of 2 was chosen for no reason in particular and can be changed if there is a more appropriate one.

Fixes: https://github.com/rlabduke/reduce/issues/5