### PR TITLE
Avoid floating point accuracy related problems with flips

### DIFF
--- a/toolclasses/Point3d.cpp
+++ b/toolclasses/Point3d.cpp
@@ -231,7 +231,11 @@ Coord dihedral(const Point3d& p1, const Point3d& p2,
 	Coord emag  = e.length();
 	Coord theta = 0.0;
 
-	if (dmag*emag >= 0.0001) { theta = acos(dot(d, e)/(dmag*emag)); }
+	if (dmag*emag >= 0.0001) {
+		theta = dot(d, e)/(dmag*emag);
+		theta = std::max(-1.0, std::min(1.0, theta));
+		theta = acos(theta);
+	}
 
 	Vector3d f = cross(d, b); // this part sets the correct handedness
 


### PR DESCRIPTION
Sometimes the normalized dot product used in the dihedral angle
calculation is affected by floating point accuracy problems resulting in
a value slightly larger than 1.0. This then leads to a NaN result from
acos(), giving invalid coordinates later on.

Fix this by clamping the value to exactly 1.0 and -1.0 respectively.

Example:
3vi2, chain A, res 312, CA

Fixes: https://github.com/rlabduke/reduce/issues/6