### PR TITLE
Avoid invalidated records when scoring methyl rotation angles

### DIFF
--- a/reduce_src/RotMethyl.cpp
+++ b/reduce_src/RotMethyl.cpp
@@ -203,6 +203,9 @@ double RotMethyl::scoreThisAngle(AtomPositions &xyz, DotSphManager& dotBucket,
 	int i = 0;
 	_rot.push_front(&_heavyAtom);
 	for(std::list<PDBrec*>::const_iterator alst = _rot.begin(); alst != _rot.end(); ++alst) {
+		if (!(*alst)->valid())
+			continue;
+
 		float bumpSubScore = 0.0;
 		float hbSubScore   = 0.0;
 		bool subBadBump    = FALSE;


### PR DESCRIPTION
Invalidated records do not have a corresponding entry in the pre-built
list of bonded atoms "_bnded" (see "RotMethyl::finalize"). When trying to
score a rotation angle in "RotMethyl::scoreThisAngle" the loop iterates
over all records, including invalidated ones and increments the counter
"i" which is used as an index to access "_bnded". This means when there
is an invalidated record, this access will be out of bounds resulting in
either a crash or incorrect results. Such a crash can be observed with
1QIR. The solution to this issue is to skip over invalidated records in
"scoreThisAngle". This does not affect the result of the function
because the called "atomScore" function exits early with a score of 0
in case of invalid records anyway.

Fixes: https://github.com/rlabduke/reduce/issues/7